### PR TITLE
Add HMAC header check if enabled in configuration

### DIFF
--- a/src/main/java/com/teradata/dmp/apisdk/config/AbstractConfig.java
+++ b/src/main/java/com/teradata/dmp/apisdk/config/AbstractConfig.java
@@ -5,6 +5,8 @@ public class AbstractConfig implements IConfig {
     protected String username;
     protected String password;
     protected int maxRetries;
+    protected boolean isHMACEnabled;
+    protected String HMACSecret;
 
     public String getEndpoint() {
         return this.endpoint;
@@ -39,5 +41,21 @@ public class AbstractConfig implements IConfig {
 
     protected void setUsername(String username) {
         this.username = username;
+    }
+
+    public boolean isHMACEnabled() {
+        return isHMACEnabled;
+    }
+
+    public String getHMACSecret() {
+        return HMACSecret;
+    }
+
+    public void setHMACSecret(String HMACSecret) {
+        this.HMACSecret = HMACSecret;
+    }
+
+    public void setHMACEnabled(boolean HMACEnabled) {
+        isHMACEnabled = HMACEnabled;
     }
 }

--- a/src/main/java/com/teradata/dmp/apisdk/config/Config.java
+++ b/src/main/java/com/teradata/dmp/apisdk/config/Config.java
@@ -5,6 +5,7 @@ public class Config extends AbstractConfig implements IConfig {
         IConfig conf = new Config();
         conf.setEndpoint("https://platform.flxone.com/api/v2");
         conf.setMaxRetries(5);
+        conf.setHMACEnabled(false);
         return conf;
     }
 }

--- a/src/main/java/com/teradata/dmp/apisdk/config/IConfig.java
+++ b/src/main/java/com/teradata/dmp/apisdk/config/IConfig.java
@@ -8,4 +8,8 @@ public interface  IConfig {
     void setEndpoint(String endpoint);
     void setCredentials(String user, String password);
     void setMaxRetries(int n);
+    String getHMACSecret();
+    boolean isHMACEnabled();
+    void setHMACEnabled(boolean b);
+    void setHMACSecret(String secret);
 }

--- a/src/test/java/TestClient.java
+++ b/src/test/java/TestClient.java
@@ -60,4 +60,35 @@ public class TestClient {
         // Validate ID
         assertTrue(resp3.getAsJsonObject("user").getAsJsonPrimitive("id").getAsString().length() > 0);
     }
+
+    @Test
+    public void testClientHMACOption() throws ClientException {
+        // Conf
+        IConfig conf = Config.getDefault();
+        conf.setHMACEnabled(true);
+
+        // Credentials are read from system env, put in ~/.bashrc (e.g. export DMP_USERNAME=test )
+        // in order to take effect you might need to reload env, restart editor or reboot machine
+        conf.setCredentials(System.getenv("DMP_USERNAME"), System.getenv("DMP_PASSWORD"));
+        String endpoint = System.getenv("DMP_ENDPOINT");
+
+        conf.setHMACSecret(System.getenv("DMP_HMAC_SECRET"));
+
+        if (endpoint != null) {
+            conf.setEndpoint(endpoint);
+        }
+
+        // Client
+        IClient client = new Client(conf);
+
+        // Request
+        IRequest req = new Request("user/current");
+
+        // Execute
+        IResponse resp = client.get(req);
+
+        // Validate ID
+        assertTrue(resp.getAsJsonObject("user").getAsJsonPrimitive("id").getAsString().length() > 0);
+    }
+
 }


### PR DESCRIPTION
Verifies if the HMAC header is correct, in case this is enabled in the config
the default is not to check for header
